### PR TITLE
Fix Font Awesome v4 icon usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             <div class="container">
                 <div class="nav-container">
                     <div class="nav-logo">
-                        <h2><i class="fas fa-rocket"></i> Rocket Meals</h2>
+                        <h2><i class="fa fa-rocket"></i> Rocket Meals</h2>
                     </div>
                     <ul class="nav-menu" role="menubar">
                         <li class="nav-item" role="none">
@@ -83,9 +83,9 @@
                     </div>
                     <div class="hero-visual" aria-hidden="true">
                         <div class="floating-elements">
-                            <div class="floating-element element-1"><i class="fas fa-mobile-screen"></i></div>
-                            <div class="floating-element element-2"><i class="fas fa-rocket"></i></div>
-                            <div class="floating-element element-3"><i class="fas fa-laptop"></i></div>
+                            <div class="floating-element element-1"><i class="fa fa-mobile"></i></div>
+                            <div class="floating-element element-2"><i class="fa fa-rocket"></i></div>
+                            <div class="floating-element element-3"><i class="fa fa-laptop"></i></div>
                         </div>
                     </div>
                 </div>
@@ -101,32 +101,32 @@
                 </div>
                 <div class="about-grid" role="region" aria-label="App Features">
                     <div class="about-card">
-                        <div class="card-icon"><i class="fas fa-calendar-days"></i></div>
+                        <div class="card-icon"><i class="fa fa-calendar"></i></div>
                         <h3>Digitaler Speiseplan</h3>
                         <p>Sieh dir den aktuellen Speiseplan deiner Mensa an - übersichtlich und immer aktuell auf deinem Smartphone.</p>
                     </div>
                     <div class="about-card">
-                        <div class="card-icon"><i class="fas fa-clock"></i></div>
+                        <div class="card-icon"><i class="fa fa-clock-o"></i></div>
                         <h3>Vorbestellfunktion</h3>
                         <p>Bestelle dein Lieblingsessen vor und spare Zeit in der Warteschlange. Einfach abholen und genießen.</p>
                     </div>
                     <div class="about-card">
-                        <div class="card-icon"><i class="fas fa-leaf"></i></div>
+                        <div class="card-icon"><i class="fa fa-leaf"></i></div>
                         <h3>Nährwertinformationen</h3>
                         <p>Informiere dich über Kalorien, Allergene und Inhaltsstoffe - für eine bewusste Ernährung im Studium.</p>
                     </div>
                     <div class="about-card">
-                        <div class="card-icon"><i class="fas fa-money-bill"></i></div>
+                        <div class="card-icon"><i class="fa fa-money"></i></div>
                         <h3>Preistransparenz</h3>
                         <p>Sieh dir Preise für Studenten, Mitarbeiter und Gäste auf einen Blick an - keine Überraschungen mehr.</p>
                     </div>
                     <div class="about-card">
-                        <div class="card-icon"><i class="fas fa-star"></i></div>
+                        <div class="card-icon"><i class="fa fa-star"></i></div>
                         <h3>Bewertungen</h3>
                         <p>Bewerte Gerichte und lies Bewertungen anderer Studenten - finde deine neuen Lieblingsgerichte.</p>
                     </div>
                     <div class="about-card">
-                        <div class="card-icon"><i class="fas fa-bell"></i></div>
+                        <div class="card-icon"><i class="fa fa-bell"></i></div>
                         <h3>Push-Benachrichtigungen</h3>
                         <p>Verpasse nie wieder dein Lieblingsgericht - erhalte Benachrichtigungen für neue Speisepläne.</p>
                     </div>
@@ -144,7 +144,7 @@
                 <div class="product-showcase">
                     <article class="product-card featured" aria-labelledby="rocket-meals-app-title">
                         <div class="product-image" aria-hidden="true">
-                            <i class="fas fa-utensils"></i>
+                            <i class="fa fa-cutlery"></i>
                         </div>
                         <div class="product-content">
                             <h3 id="rocket-meals-app-title">Rocket Meals</h3>
@@ -176,10 +176,10 @@
                             </div>
                             <div class="hero-buttons">
                                 <a href="#" class="btn btn-primary" aria-label="App Store Download (Coming Soon)">
-                                    <i class="fas fa-mobile-screen"></i> App Store
+                                    <i class="fa fa-apple"></i> App Store
                                 </a>
                                 <a href="#" class="btn btn-primary" aria-label="Google Play Download (Coming Soon)">
-                                    <i class="fas fa-mobile-screen"></i> Google Play
+                                    <i class="fa fa-android"></i> Google Play
                                 </a>
                             </div>
                         </div>
@@ -222,7 +222,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3><i class="fas fa-rocket"></i> Rocket Meals</h3>
+                    <h3><i class="fa fa-rocket"></i> Rocket Meals</h3>
                     <p>Die innovative Mensa-App für Studenten und Studierendenwerke</p>
                     <p>Entwickelt mit ❤️ für die Student Community</p>
                 </div>
@@ -235,18 +235,18 @@
                 <div class="footer-section">
                     <h4>Features</h4>
                     <ul role="list">
-                        <li role="listitem"><i class="fas fa-calendar-days"></i> Digitaler Speiseplan</li>
-                        <li role="listitem"><i class="fas fa-clock"></i> Vorbestellfunktion</li>
-                        <li role="listitem"><i class="fas fa-leaf"></i> Nährwertinformationen</li>
-                        <li role="listitem"><i class="fas fa-star"></i> Bewertungssystem</li>
+                        <li role="listitem"><i class="fa fa-calendar"></i> Digitaler Speiseplan</li>
+                        <li role="listitem"><i class="fa fa-clock-o"></i> Vorbestellfunktion</li>
+                        <li role="listitem"><i class="fa fa-leaf"></i> Nährwertinformationen</li>
+                        <li role="listitem"><i class="fa fa-star"></i> Bewertungssystem</li>
                     </ul>
                 </div>
                 <div class="footer-section">
                     <h4>Download</h4>
                     <ul role="list">
-                        <li role="listitem"><a href="#" aria-label="iOS App Download (Coming Soon)"><i class="fas fa-mobile-screen"></i> iOS App (Coming Soon)</a></li>
-                        <li role="listitem"><a href="#" aria-label="Android App Download (Coming Soon)"><i class="fas fa-mobile-screen"></i> Android App (Coming Soon)</a></li>
-                        <li role="listitem"><a href="#contact" aria-label="Für Studierendenwerke"><i class="fas fa-building"></i> Für Studierendenwerke</a></li>
+                        <li role="listitem"><a href="#" aria-label="iOS App Download (Coming Soon)"><i class="fa fa-apple"></i> iOS App (Coming Soon)</a></li>
+                        <li role="listitem"><a href="#" aria-label="Android App Download (Coming Soon)"><i class="fa fa-android"></i> Android App (Coming Soon)</a></li>
+                        <li role="listitem"><a href="#contact" aria-label="Für Studierendenwerke"><i class="fa fa-building"></i> Für Studierendenwerke</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace Font Awesome 5/6 class names in `index.html` with the proper v4 `fa` syntax
- swap unsupported icon identifiers for the closest v4 equivalents (e.g., calendar, clock, cutlery, Apple/Android)

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caa5e53088833086dbe0707fd3023f