### PR TITLE
Refactor Cookiebot script into shared asset

### DIFF
--- a/assets/js/cookiebot.js
+++ b/assets/js/cookiebot.js
@@ -1,0 +1,20 @@
+(function loadCookiebot() {
+    if (document.getElementById('Cookiebot')) {
+        return;
+    }
+
+    var script = document.createElement('script');
+    script.id = 'Cookiebot';
+    script.src = 'https://consent.cookiebot.com/uc.js';
+    script.type = 'text/javascript';
+    script.setAttribute('data-cbid', '1aaaafb2-1ba3-470b-80dd-d7cc641f15c3');
+    script.setAttribute('data-blockingmode', 'auto');
+    script.async = false;
+
+    var head = document.head || document.getElementsByTagName('head')[0];
+    if (head) {
+        head.appendChild(script);
+    } else {
+        document.documentElement.appendChild(script);
+    }
+})();

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -21,7 +21,7 @@
     <meta property="twitter:description" content="Alles über Datenschutz, Hosting und Kontaktformular auf der Rocket Meals Website.">
     <meta property="twitter:image" content="/assets/images/logo.png">
 
-    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="1aaaafb2-1ba3-470b-80dd-d7cc641f15c3" data-blockingmode="auto" type="text/javascript"></script>
+    <script src="assets/js/cookiebot.js"></script>
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/assets/images/favicon.svg">

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <meta property="twitter:description" content="Rocket Meals - Die mobile App für Studierendenwerke und Mensen. Digitaler Speiseplan, Vorbestellfunktion und Nährwertinformationen in einer App.">
     <meta property="twitter:image" content="/assets/images/logo.png">
 
-    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="1aaaafb2-1ba3-470b-80dd-d7cc641f15c3" data-blockingmode="auto" type="text/javascript"></script>
+    <script src="assets/js/cookiebot.js"></script>
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/assets/images/favicon.svg">


### PR DESCRIPTION
## Summary
- extract the Cookiebot loader into `assets/js/cookiebot.js`
- include the shared loader in `index.html` and `datenschutz.html`

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cab1e7a6c88330b8fc5f655773ee60