### PR TITLE
Fix Cookiebot integration for contact form

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -19,6 +19,10 @@
     --transition: all 0.3s ease;
 }
 
+[hidden] {
+    display: none !important;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
     line-height: 1.6;
@@ -143,6 +147,7 @@ body {
     font-weight: 600;
     transition: var(--transition);
     border: 2px solid transparent;
+    cursor: pointer;
 }
 
 .btn-primary {
@@ -388,6 +393,10 @@ body {
     padding: 3rem;
     text-align: center;
     color: var(--text-light);
+}
+
+.form-placeholder p {
+    margin-bottom: 1.5rem;
 }
 
 /* Footer */

--- a/assets/js/cookiebot.js
+++ b/assets/js/cookiebot.js
@@ -1,20 +1,95 @@
-(function loadCookiebot() {
-    if (document.getElementById('Cookiebot')) {
-        return;
+(function () {
+    function loadCookiebot() {
+        if (document.getElementById('Cookiebot')) {
+            return;
+        }
+
+        var script = document.createElement('script');
+        script.id = 'Cookiebot';
+        script.src = 'https://consent.cookiebot.com/uc.js';
+        script.type = 'text/javascript';
+        script.setAttribute('data-cbid', '1aaaafb2-1ba3-470b-80dd-d7cc641f15c3');
+        script.setAttribute('data-blockingmode', 'auto');
+        script.async = false;
+
+        var head = document.head || document.getElementsByTagName('head')[0];
+        if (head) {
+            head.appendChild(script);
+        } else {
+            document.documentElement.appendChild(script);
+        }
     }
 
-    var script = document.createElement('script');
-    script.id = 'Cookiebot';
-    script.src = 'https://consent.cookiebot.com/uc.js';
-    script.type = 'text/javascript';
-    script.setAttribute('data-cbid', '1aaaafb2-1ba3-470b-80dd-d7cc641f15c3');
-    script.setAttribute('data-blockingmode', 'auto');
-    script.async = false;
+    function initContactFormConsentHandling() {
+        document.addEventListener('DOMContentLoaded', function () {
+            var contactIframe = document.getElementById('contact-form-iframe');
+            if (!contactIframe) {
+                return;
+            }
 
-    var head = document.head || document.getElementsByTagName('head')[0];
-    if (head) {
-        head.appendChild(script);
-    } else {
-        document.documentElement.appendChild(script);
+            var formUrl = contactIframe.getAttribute('data-src');
+            var placeholder = document.getElementById('contact-form-placeholder');
+            var settingsButton = document.getElementById('cookie-settings-button');
+
+            if (settingsButton) {
+                settingsButton.addEventListener('click', function () {
+                    if (window.Cookiebot && typeof window.Cookiebot.show === 'function') {
+                        window.Cookiebot.show();
+                    }
+                });
+            }
+
+            function showForm() {
+                if (formUrl && contactIframe.src !== formUrl) {
+                    contactIframe.src = formUrl;
+                }
+                contactIframe.style.display = '';
+                contactIframe.removeAttribute('aria-hidden');
+
+                if (placeholder) {
+                    placeholder.hidden = true;
+                }
+            }
+
+            function showPlaceholder() {
+                if (formUrl && contactIframe.src !== 'about:blank') {
+                    contactIframe.src = 'about:blank';
+                }
+                contactIframe.style.display = 'none';
+                contactIframe.setAttribute('aria-hidden', 'true');
+
+                if (placeholder) {
+                    placeholder.hidden = false;
+                }
+            }
+
+            function updateContactFormVisibility() {
+                if (window.Cookiebot && window.Cookiebot.consent) {
+                    var consent = window.Cookiebot.consent;
+                    var allowForm = Boolean(
+                        consent.marketing ||
+                        consent.statistics ||
+                        consent.preferences
+                    );
+
+                    if (allowForm) {
+                        showForm();
+                    } else {
+                        showPlaceholder();
+                    }
+                } else {
+                    showForm();
+                }
+            }
+
+            updateContactFormVisibility();
+
+            window.addEventListener('CookiebotOnConsentReady', updateContactFormVisibility);
+            window.addEventListener('CookiebotOnAccept', updateContactFormVisibility);
+            window.addEventListener('CookiebotOnDecline', updateContactFormVisibility);
+        });
     }
+
+    loadCookiebot();
+    initContactFormConsentHandling();
 })();

--- a/index.html
+++ b/index.html
@@ -203,16 +203,24 @@
                 <div class="contact-content">
                     <div class="contact-form">
                         <h3 id="contact-form-title">Kontaktformular</h3>
-                        <iframe 
-                            src="https://docs.google.com/forms/d/1s8HnwOeR1ETfNYpWuu7nUYTSBWGprTF97wz-Fd9d_4Y/viewform?embedded=true" 
-                            width="100%" 
-                            height="1400" 
-                            frameborder="0" 
-                            marginheight="0" 
+                        <div id="contact-form-placeholder" class="form-placeholder" hidden role="status" aria-live="polite">
+                            <p>Um das Kontaktformular zu laden, erlaube bitte Cookies für Statistiken oder Marketing.</p>
+                            <button type="button" class="btn btn-secondary" id="cookie-settings-button">Cookie-Einstellungen öffnen</button>
+                        </div>
+                        <iframe
+                            id="contact-form-iframe"
+                            src="https://docs.google.com/forms/d/1s8HnwOeR1ETfNYpWuu7nUYTSBWGprTF97wz-Fd9d_4Y/viewform?embedded=true"
+                            data-src="https://docs.google.com/forms/d/1s8HnwOeR1ETfNYpWuu7nUYTSBWGprTF97wz-Fd9d_4Y/viewform?embedded=true"
+                            width="100%"
+                            height="1400"
+                            frameborder="0"
+                            marginheight="0"
                             marginwidth="0"
                             title="Kontaktformular - Baumgartner Software UG"
                             aria-label="Google Forms Kontaktformular"
                             aria-describedby="contact-form-title"
+                            loading="lazy"
+                            data-cookieconsent="marketing"
                             style="width:100%; max-width:100%; overflow-x:hidden; border:none;"
                             >
                             Laden...


### PR DESCRIPTION
## Summary
- add a consent-aware placeholder and metadata to the contact form iframe so that the Google Form can load after approval
- enhance styling to hide placeholders cleanly and improve button interactions
- extend the Cookiebot helper script to toggle the iframe and show a cookie settings shortcut based on granted consent

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cab5beefc8833080c2f28514e65ef6