### PR TITLE
Add consent-based placeholder before loading contact form

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -399,6 +399,30 @@ body {
     margin-bottom: 1.5rem;
 }
 
+.form-placeholder .placeholder-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: stretch;
+}
+
+.form-placeholder .placeholder-note {
+    font-size: 0.9rem;
+    margin-bottom: 0;
+}
+
+@media (min-width: 600px) {
+    .form-placeholder .placeholder-actions {
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .form-placeholder .placeholder-actions .btn {
+        min-width: 220px;
+    }
+}
+
 /* Footer */
 .footer {
     background: var(--secondary-color);

--- a/index.html
+++ b/index.html
@@ -203,13 +203,18 @@
                 <div class="contact-content">
                     <div class="contact-form">
                         <h3 id="contact-form-title">Kontaktformular</h3>
-                        <div id="contact-form-placeholder" class="form-placeholder" hidden role="status" aria-live="polite">
-                            <p>Um das Kontaktformular zu laden, erlaube bitte Cookies für Statistiken oder Marketing.</p>
-                            <button type="button" class="btn btn-secondary" id="cookie-settings-button">Cookie-Einstellungen öffnen</button>
+                        <div id="contact-form-placeholder" class="form-placeholder" role="region" aria-live="polite" aria-label="Hinweis zu externen Inhalten">
+                            <p>Um das Kontaktformular von Google anzuzeigen, müssen externe Inhalte geladen werden. Dabei können personenbezogene Daten an Google übertragen werden.</p>
+                            <p>Mit einem Klick auf „Ich stimme zu und lade das Formular“ willigst du in die Datenübertragung ein.</p>
+                            <div class="placeholder-actions" role="group" aria-label="Aktionen zur Einwilligung">
+                                <button type="button" class="btn btn-primary" id="load-contact-form-button">Ich stimme zu und lade das Formular</button>
+                                <button type="button" class="btn btn-secondary" id="cookie-settings-button">Cookie-Einstellungen öffnen</button>
+                            </div>
+                            <p class="placeholder-note">Du kannst deine Entscheidung jederzeit über die Cookie-Einstellungen widerrufen.</p>
                         </div>
                         <iframe
                             id="contact-form-iframe"
-                            src="https://docs.google.com/forms/d/1s8HnwOeR1ETfNYpWuu7nUYTSBWGprTF97wz-Fd9d_4Y/viewform?embedded=true"
+                            src="about:blank"
                             data-src="https://docs.google.com/forms/d/1s8HnwOeR1ETfNYpWuu7nUYTSBWGprTF97wz-Fd9d_4Y/viewform?embedded=true"
                             width="100%"
                             height="1400"
@@ -221,7 +226,8 @@
                             aria-describedby="contact-form-title"
                             loading="lazy"
                             data-cookieconsent="marketing"
-                            style="width:100%; max-width:100%; overflow-x:hidden; border:none;"
+                            aria-hidden="true"
+                            style="display:none; width:100%; max-width:100%; overflow-x:hidden; border:none;"
                             >
                             Laden...
                         </iframe>


### PR DESCRIPTION
## Summary
- show a consent notice instead of the Google Forms iframe until the visitor approves external content
- remember manual approval, react to Cookiebot consent events and load the iframe only after consent is present
- adjust placeholder styling to support the new action buttons and keep the iframe hidden until it may load

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cab8ea074c8330a6804d4fa6207dd3